### PR TITLE
Fix: Improve scan credit handling

### DIFF
--- a/src/commands/report-command.handler.ts
+++ b/src/commands/report-command.handler.ts
@@ -1,30 +1,33 @@
-import type { UUID } from 'node:crypto';
-import { lookupForProjects } from '@fixentropy-io/package-installer';
+import { verify, type UUID } from "node:crypto";
+import { lookupForProjects } from "@fixentropy-io/package-installer";
 import {
-    HtmlReportBuilder,
-    JsonReportBuilder,
-    MarkdownReportBuilder
-} from '@fixentropy-io/report-generator';
-import { type Asserter, type Report, asserterHandler } from '@fixentropy-io/type/asserter';
-import { config } from '../cli.config.ts';
-import { lookupForDragees } from '../dragee-lookup.ts';
-import { lookupForNamespaces } from '../namespace-lookup.ts';
+  HtmlReportBuilder,
+  JsonReportBuilder,
+  MarkdownReportBuilder,
+} from "@fixentropy-io/report-generator";
 import {
-    getIfOptinChoiceHasBeenMade,
-    subscribeToNewsletterHandler
-} from './newsletter-subscription.handler.ts';
-
+  type Asserter,
+  type Report,
+  asserterHandler,
+} from "@fixentropy-io/type/asserter";
+import { config } from "../cli.config.ts";
+import { lookupForDragees } from "../dragee-lookup.ts";
+import { lookupForNamespaces } from "../namespace-lookup.ts";
+import {
+  getIfOptinChoiceHasBeenMade,
+  subscribeToNewsletterHandler,
+} from "./newsletter-subscription.handler.ts";
 
 // ── Types ──────────────────────────────────────────────────────────────
 
 type Options = {
-    fromDir: string;
-    toDir: string;
-    publish: boolean;
+  fromDir: string;
+  toDir: string;
+  publish: boolean;
 };
 
 type ScanCreditResponse = {
-    scanCreditId: UUID;
+  scanCreditId: UUID;
 };
 
 type ScanReportStats = {
@@ -46,162 +49,157 @@ type ScanReport = {
 };
 
 type PublishContext = {
-    backendUrl: string;
-    scanCreditId: UUID;
+  backendUrl: string;
+  scanCreditId: UUID;
 };
 
 class ScanCreditError extends Error {
-    constructor() {
-        super('Failed to credit the scan');
-    }
+  constructor() {
+    super("Failed to credit the scan");
+  }
 }
 
 class ScanPublishError extends Error {
-    constructor() {
-        super('Failed to publish reports to backend');
-    }
+  constructor() {
+    super("Failed to publish reports to backend");
+  }
 }
-
 
 // ── Backend API ────────────────────────────────────────────────────────
 
 const getBackendUrl = (): string | undefined => process.env.BACKEND_URL;
 
-const creditScan = async (backendUrl: string, oidcToken: string): Promise<ScanCreditResponse> => {
-    const response = await fetch(`${backendUrl}/scans/credit`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ oidcToken })
-    });
+const creditScan = async (
+  backendUrl: string,
+  oidcToken: string,
+): Promise<UUID> => {
+  const response = await fetch(`${backendUrl}/scans/credit`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ oidcToken }),
+  });
 
-    if (!response.ok) {
-        throw new Error(`Failed to credit scan: ${response.status} ${response.statusText}`);
-    }
+  if (!response.ok) {
+    throw new ScanCreditError();
+  }
 
-    return response.json() as Promise<ScanCreditResponse>;
+  const scanCreditResponse =
+    (await response.json()) as Promise<ScanCreditResponse>;
+  const scanCreditId = (await scanCreditResponse).scanCreditId;
+  console.log(`Scan credited successfully with ID: ${scanCreditId}`);
+  return scanCreditId;
 };
 
 const publishReports = async (
-    backendUrl: string,
-    scanCreditId: UUID,
-    reports: ScanReport[]
+  backendUrl: string,
+  scanCreditId: UUID,
+  reports: Report[],
 ): Promise<void> => {
-    const response = await fetch(`${backendUrl}/scans/report`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ scanCreditId, reports })
-    });
+  const scanReports: ScanReport[] = reports.map(
+    (report): ScanReport => ({
+      namespace: report.namespace,
+      issues: report.errors.map((error) => ({
+        ruleName: error.ruleId || "",
+        drageeName: error.drageeName,
+        message: error.message,
+      })),
+      stats: {
+        numberOfAsserterRules: report.stats.rulesCount,
+        numberOfValidatedDependencies: report.stats.passCount,
+        numberOfRejectedDependencies: report.stats.errorsCount,
+      },
+    }),
+  );
 
-    if (!response.ok) {
-        throw new Error(`Failed to publish reports: ${response.status} ${response.statusText}`);
-    }
-};
+  const response = await fetch(`${backendUrl}/scans/report`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ scanCreditId, scanReports }),
+  });
 
-// ── Publish orchestration ──────────────────────────────────────────────
+  if (!response.ok) {
+    throw new ScanPublishError();
+  }
 
-const tryInitializePublish = async (): Promise<PublishContext | null> => {
-    const oidcToken = process.env.OIDC_TOKEN;
-    const backendUrl = getBackendUrl();
-
-    if (!oidcToken) {
-        console.warn('--publish: OIDC_TOKEN is not set, skipping backend publish.');
-        return null;
-    }
-
-    if (!backendUrl) {
-        console.warn('--publish: BACKEND_URL is not set, skipping backend publish.');
-        return null;
-    }
-
-    try {
-        console.log('Starting scan session...');
-        const scan = await creditScan(backendUrl, oidcToken);
-        return { backendUrl, scanCreditId: scan.scanCreditId };
-    } catch {
-        throw new ScanCreditError();
-    }
-};
-
-const tryPublishReports = async (publishContext: PublishContext, reports: Report[]): Promise<void> => {
-    try {
-        console.log(
-            `Scan credited (id: ${publishContext.scanCreditId}), publishing ${reports.length} report(s)...`
-        );
-        const scanReports: ScanReport[] = reports.map((report): ScanReport => ({
-            namespace: report.namespace,
-            issues: report.errors.map(error => ({
-                ruleName: error.ruleId || '',
-                drageeName: error.drageeName,
-                message: error.message
-            })),
-            stats: {
-                numberOfAsserterRules: report.stats.rulesCount,
-                numberOfValidatedDependencies: report.stats.passCount,
-                numberOfRejectedDependencies: report.stats.errorsCount
-            }
-        }));
-        await publishReports(publishContext.backendUrl, publishContext.scanCreditId, scanReports);
-
-        console.log('Reports published successfully');
-    } catch {
-        throw new ScanPublishError();
-    }
+  console.log("Reports published successfully");
 };
 
 // ── Report building ────────────────────────────────────────────────────
 
 export const buildReports = (reports: Report[], filePath: string) => {
-    JsonReportBuilder.buildReports(reports, filePath);
-    HtmlReportBuilder.buildReports(reports, filePath);
-    MarkdownReportBuilder.buildReports(reports, filePath);
+  JsonReportBuilder.buildReports(reports, filePath);
+  HtmlReportBuilder.buildReports(reports, filePath);
+  MarkdownReportBuilder.buildReports(reports, filePath);
 };
 
 // ── Main handler ───────────────────────────────────────────────────────
 
-export const reportCommandhandler = async ({ fromDir, toDir, publish }: Options) => {
-    try {
-        // Fail fast in CI when scan credit is denied to avoid unnecessary local processing.
-        const publishContext = publish ? await tryInitializePublish() : null;
-
-        const dragees = await lookupForDragees(fromDir);
-        const namespaces = await lookupForNamespaces(dragees);
-        const asserters: Asserter[] = await lookupForProjects(
-            config.projectsRegistryUrl,
-            config.localRegistryPath,
-            namespaces.map(n => `${n}-asserter`)
+export const reportCommandhandler = async ({
+  fromDir,
+  toDir,
+  publish,
+}: Options) => {
+  try {
+    let scanCreditId: UUID | null = null;
+    const oidcToken = process.env.OIDC_TOKEN;
+    const backendUrl = getBackendUrl();
+    if (publish) {
+      if (!oidcToken) {
+        console.warn(
+          "--publish: OIDC_TOKEN is not set, skipping backend publish.",
         );
+        return null;
+      }
 
-        const reports: Report[] = [];
-        for (const asserter of asserters) {
-            console.log(`Running asserter for namespace ${asserter.namespace}`);
-            reports.push(asserterHandler(asserter, dragees));
-        }
-
-        // Always generate local reports
-        buildReports(reports, `${toDir}/result`);
-
-        // Optionally publish to backend
-        if (publishContext) {
-            await tryPublishReports(publishContext, reports);
-        }
-
-        askForUpdatesByEmail();
-    } catch (error) {
-        if (error instanceof ScanCreditError || error instanceof ScanPublishError) {
-            console.error(error.message);
-        } else if (error instanceof Error) {
-            console.error(error.message);
-        } else {
-            console.error('An unexpected error occurred');
-        }
-        process.exitCode = 1;
+      if (!backendUrl) {
+        console.warn(
+          "--publish: BACKEND_URL is not set, skipping backend publish.",
+        );
+        return null;
+      }
+      console.log("Crediting scan...");
+      scanCreditId = publish ? await creditScan(backendUrl, oidcToken) : null;
     }
+
+    const dragees = await lookupForDragees(fromDir);
+    const namespaces = await lookupForNamespaces(dragees);
+    const asserters: Asserter[] = await lookupForProjects(
+      config.projectsRegistryUrl,
+      config.localRegistryPath,
+      namespaces.map((n) => `${n}-asserter`),
+    );
+
+    const reports: Report[] = [];
+    for (const asserter of asserters) {
+      console.log(`Running asserter for namespace ${asserter.namespace}`);
+      reports.push(asserterHandler(asserter, dragees));
+    }
+
+    buildReports(reports, `${toDir}/result`);
+
+    // Optionally publish to backend
+    if (publish && scanCreditId) {
+      console.log(`Publishing ${reports.length} report(s)...`);
+      await publishReports(backendUrl ?? "", scanCreditId, reports);
+    }
+
+    askForUpdatesByEmail();
+  } catch (error) {
+    if (error instanceof ScanCreditError || error instanceof ScanPublishError) {
+      console.error(error.message);
+    } else if (error instanceof Error) {
+      console.error(error.message);
+    } else {
+      console.error("An unexpected error occurred");
+    }
+    process.exitCode = 1;
+  }
 };
 
 // ── Newsletter ─────────────────────────────────────────────────────────
 
 const askForUpdatesByEmail = () => {
-    if (!getIfOptinChoiceHasBeenMade()) {
-        subscribeToNewsletterHandler();
-    }
+  if (!getIfOptinChoiceHasBeenMade()) {
+    subscribeToNewsletterHandler();
+  }
 };

--- a/src/commands/report-command.handler.ts
+++ b/src/commands/report-command.handler.ts
@@ -45,6 +45,23 @@ type ScanReport = {
   stats: ScanReportStats;
 };
 
+type PublishContext = {
+    backendUrl: string;
+    scanCreditId: UUID;
+};
+
+class ScanCreditError extends Error {
+    constructor() {
+        super('Failed to credit the scan');
+    }
+}
+
+class ScanPublishError extends Error {
+    constructor() {
+        super('Failed to publish reports to backend');
+    }
+}
+
 
 // ── Backend API ────────────────────────────────────────────────────────
 
@@ -82,25 +99,34 @@ const publishReports = async (
 
 // ── Publish orchestration ──────────────────────────────────────────────
 
-const tryPublishReports = async (reports: Report[]): Promise<void> => {
+const tryInitializePublish = async (): Promise<PublishContext | null> => {
     const oidcToken = process.env.OIDC_TOKEN;
     const backendUrl = getBackendUrl();
 
     if (!oidcToken) {
         console.warn('--publish: OIDC_TOKEN is not set, skipping backend publish.');
-        return;
+        return null;
     }
 
     if (!backendUrl) {
         console.warn('--publish: BACKEND_URL is not set, skipping backend publish.');
-        return;
+        return null;
     }
 
     try {
         console.log('Starting scan session...');
         const scan = await creditScan(backendUrl, oidcToken);
+        return { backendUrl, scanCreditId: scan.scanCreditId };
+    } catch {
+        throw new ScanCreditError();
+    }
+};
 
-        console.log(`Scan credited (id: ${scan.scanCreditId}), publishing ${reports.length} report(s)...`);
+const tryPublishReports = async (publishContext: PublishContext, reports: Report[]): Promise<void> => {
+    try {
+        console.log(
+            `Scan credited (id: ${publishContext.scanCreditId}), publishing ${reports.length} report(s)...`
+        );
         const scanReports: ScanReport[] = reports.map((report): ScanReport => ({
             namespace: report.namespace,
             issues: report.errors.map(error => ({
@@ -114,11 +140,11 @@ const tryPublishReports = async (reports: Report[]): Promise<void> => {
                 numberOfRejectedDependencies: report.stats.errorsCount
             }
         }));
-        await publishReports(backendUrl, scan.scanCreditId, scanReports);
+        await publishReports(publishContext.backendUrl, publishContext.scanCreditId, scanReports);
 
         console.log('Reports published successfully');
-    } catch (error) {
-        console.error('Failed to publish reports to backend:', error);
+    } catch {
+        throw new ScanPublishError();
     }
 };
 
@@ -133,29 +159,43 @@ export const buildReports = (reports: Report[], filePath: string) => {
 // ── Main handler ───────────────────────────────────────────────────────
 
 export const reportCommandhandler = async ({ fromDir, toDir, publish }: Options) => {
-    const dragees = await lookupForDragees(fromDir);
-    const namespaces = await lookupForNamespaces(dragees);
-    const asserters: Asserter[] = await lookupForProjects(
-        config.projectsRegistryUrl,
-        config.localRegistryPath,
-        namespaces.map(n => `${n}-asserter`)
-    );
+    try {
+        // Fail fast in CI when scan credit is denied to avoid unnecessary local processing.
+        const publishContext = publish ? await tryInitializePublish() : null;
 
-    const reports: Report[] = [];
-    for (const asserter of asserters) {
-        console.log(`Running asserter for namespace ${asserter.namespace}`);
-        reports.push(asserterHandler(asserter, dragees));
+        const dragees = await lookupForDragees(fromDir);
+        const namespaces = await lookupForNamespaces(dragees);
+        const asserters: Asserter[] = await lookupForProjects(
+            config.projectsRegistryUrl,
+            config.localRegistryPath,
+            namespaces.map(n => `${n}-asserter`)
+        );
+
+        const reports: Report[] = [];
+        for (const asserter of asserters) {
+            console.log(`Running asserter for namespace ${asserter.namespace}`);
+            reports.push(asserterHandler(asserter, dragees));
+        }
+
+        // Always generate local reports
+        buildReports(reports, `${toDir}/result`);
+
+        // Optionally publish to backend
+        if (publishContext) {
+            await tryPublishReports(publishContext, reports);
+        }
+
+        askForUpdatesByEmail();
+    } catch (error) {
+        if (error instanceof ScanCreditError || error instanceof ScanPublishError) {
+            console.error(error.message);
+        } else if (error instanceof Error) {
+            console.error(error.message);
+        } else {
+            console.error('An unexpected error occurred');
+        }
+        process.exitCode = 1;
     }
-
-    // Always generate local reports
-    buildReports(reports, `${toDir}/result`);
-
-    // Optionally publish to backend
-    if (publish) {
-        await tryPublishReports(reports);
-    }
-
-    askForUpdatesByEmail();
 };
 
 // ── Newsletter ─────────────────────────────────────────────────────────


### PR DESCRIPTION
This pull request refactors the backend report publishing logic to improve error handling, make the publish process more robust, and ensure early failure in CI if scan crediting fails. The changes introduce custom error classes, split the publish process into initialization and publishing steps, and enhance error reporting in the main handler.

**Error handling and robustness improvements:**

* Introduced `ScanCreditError` and `ScanPublishError` custom error classes for clearer error reporting during the scan credit and publish steps.
* Refactored the publish flow into two steps: `tryInitializePublish` (for scan crediting and context setup) and `tryPublishReports` (for actual report publishing), improving separation of concerns and early failure in CI if scan crediting fails. [[1]](diffhunk://#diff-883517f179400714e4440d471e52ca48be30aac96b08ca7c49740eb517ebfb2dL85-R129) [[2]](diffhunk://#diff-883517f179400714e4440d471e52ca48be30aac96b08ca7c49740eb517ebfb2dL117-R147)

**Main handler updates:**

* Updated `reportCommandhandler` to use the new publish flow, fail fast if scan crediting fails, and provide more descriptive error messages; also sets the process exit code on failure. [[1]](diffhunk://#diff-883517f179400714e4440d471e52ca48be30aac96b08ca7c49740eb517ebfb2dR162-R165) [[2]](diffhunk://#diff-883517f179400714e4440d471e52ca48be30aac96b08ca7c49740eb517ebfb2dL154-R198)