### PR TITLE
Feat/26/score entropy

### DIFF
--- a/src/commands/report-command.handler.ts
+++ b/src/commands/report-command.handler.ts
@@ -226,8 +226,6 @@ export const reportCommandhandler = async ({
 
     buildReports(reports, `${toDir}/result`);
 
-    console.log(calculatePassRate(reports, buildSeverityByRuleId(asserters)));
-
     // Optionally publish to backend
     if (publish && scanCreditId) {
       console.log(`Publishing ${reports.length} report(s)...`);

--- a/src/commands/report-command.handler.ts
+++ b/src/commands/report-command.handler.ts
@@ -91,7 +91,7 @@ const creditScan = async (
   return scanCreditId;
 };
 
-const publishReports = async (
+export const publishReports = async (
   backendUrl: string,
   scanCreditId: UUID,
   reports: Report[],

--- a/src/commands/report-command.handler.ts
+++ b/src/commands/report-command.handler.ts
@@ -130,10 +130,11 @@ export const publishReports = async (
 
 // ── Calculating Pass Rate ──────────────────────────────────────────────
 
+// TODO: Define rules with different severities so we can test calculating the score with different weights
 const SEVERITY_WEIGHTS: Record<RuleSeverity, number> = {
   [RuleSeverity.INFO]: 1,
-  [RuleSeverity.WARN]: 5,
-  [RuleSeverity.ERROR]: 20,
+  [RuleSeverity.WARN]: 1,
+  [RuleSeverity.ERROR]: 1,
 };
 
 export const buildSeverityByRuleId = (

--- a/src/commands/report-command.handler.ts
+++ b/src/commands/report-command.handler.ts
@@ -8,6 +8,7 @@ import {
 import {
   type Asserter,
   type Report,
+  type ReportStats,
   asserterHandler,
 } from "@fixentropy-io/type/asserter";
 import { config } from "../cli.config.ts";
@@ -111,10 +112,13 @@ const publishReports = async (
     }),
   );
 
+  const stats = reports.map((report) => report.stats);
+  const failureRate = calculateFailureRate(stats);
+
   const response = await fetch(`${backendUrl}/scans/report`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ scanCreditId, scanReports }),
+    body: JSON.stringify({ scanCreditId, scanReports, failureRate }),
   });
 
   if (!response.ok) {
@@ -122,6 +126,18 @@ const publishReports = async (
   }
 
   console.log("Reports published successfully");
+};
+
+// ── Calculating Failure Rate ──────────────────────────────────────────────────
+
+export const calculateFailureRate = (stats: ReportStats[]): number | null => {
+  const totalCount = stats.reduce(
+    (acc, stat) => acc + stat.errorsCount + stat.passCount,
+    0,
+  );
+  const errorCount = stats.reduce((acc, stat) => acc + stat.errorsCount, 0);
+
+  return totalCount > 0 ? errorCount / totalCount : null;
 };
 
 // ── Report building ────────────────────────────────────────────────────

--- a/src/commands/report-command.handler.ts
+++ b/src/commands/report-command.handler.ts
@@ -113,12 +113,12 @@ const publishReports = async (
   );
 
   const stats = reports.map((report) => report.stats);
-  const score = calculateScore(stats);
+  const passRate = calculatePassRate(stats);
 
   const response = await fetch(`${backendUrl}/scans/report`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ scanCreditId, scanReports, score }),
+    body: JSON.stringify({ scanCreditId, scanReports, score: passRate }),
   });
 
   if (!response.ok) {
@@ -128,9 +128,10 @@ const publishReports = async (
   console.log("Reports published successfully");
 };
 
-// ── Calculating Score ──────────────────────────────────────────────────
-// Have to define what are the levels of severity of an error
-export const calculateScore = (stats: ReportStats[]): number | null => {
+// ── Calculating Pass Rate ──────────────────────────────────────────────
+// TODO(#19): provisional scoring — every evaluation weighs the same.
+// Weight by error severity once severity levels are defined.
+export const calculatePassRate = (stats: ReportStats[]): number | null => {
   const totalCount = stats.reduce(
     (acc, stat) => acc + stat.errorsCount + stat.passCount,
     0,

--- a/src/commands/report-command.handler.ts
+++ b/src/commands/report-command.handler.ts
@@ -130,7 +130,7 @@ export const publishReports = async (
 
 // ── Calculating Pass Rate ──────────────────────────────────────────────
 
-// TODO: Define rules with different severities so we can test calculating the score with different weights
+// TODO: Enable differentiated weights once rules with varying severities exist
 const SEVERITY_WEIGHTS: Record<RuleSeverity, number> = {
   [RuleSeverity.INFO]: 1,
   [RuleSeverity.WARN]: 1,

--- a/src/commands/report-command.handler.ts
+++ b/src/commands/report-command.handler.ts
@@ -113,12 +113,12 @@ const publishReports = async (
   );
 
   const stats = reports.map((report) => report.stats);
-  const failureRate = calculateFailureRate(stats);
+  const score = calculateScore(stats);
 
   const response = await fetch(`${backendUrl}/scans/report`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ scanCreditId, scanReports, failureRate }),
+    body: JSON.stringify({ scanCreditId, scanReports, score }),
   });
 
   if (!response.ok) {
@@ -128,16 +128,16 @@ const publishReports = async (
   console.log("Reports published successfully");
 };
 
-// ── Calculating Failure Rate ──────────────────────────────────────────────────
-
-export const calculateFailureRate = (stats: ReportStats[]): number | null => {
+// ── Calculating Score ──────────────────────────────────────────────────
+// Have to define what are the levels of severity of an error
+export const calculateScore = (stats: ReportStats[]): number | null => {
   const totalCount = stats.reduce(
     (acc, stat) => acc + stat.errorsCount + stat.passCount,
     0,
   );
-  const errorCount = stats.reduce((acc, stat) => acc + stat.errorsCount, 0);
+  const passCount = stats.reduce((acc, stat) => acc + stat.passCount, 0);
 
-  return totalCount > 0 ? errorCount / totalCount : null;
+  return totalCount > 0 ? passCount / totalCount : null;
 };
 
 // ── Report building ────────────────────────────────────────────────────

--- a/src/commands/report-command.handler.ts
+++ b/src/commands/report-command.handler.ts
@@ -150,24 +150,25 @@ export const calculatePassRate = (
   reports: Report[],
   severityByRuleId: Map<string, RuleSeverity>,
 ): number | null => {
-  const totalEvaluations = reports.reduce(
-    (acc, report) => acc + report.stats.passCount + report.stats.errorsCount,
-    0,
-  );
-  if (totalEvaluations === 0) {
-    return null;
-  }
-
   const passCount = reports.reduce(
     (acc, report) => acc + report.stats.passCount,
     0,
   );
+  const failureCount = reports.reduce(
+    (acc, report) => acc + report.errors.length,
+    0,
+  );
+  if (passCount + failureCount === 0) {
+    return null;
+  }
+
   const weightedFailureCount = reports.reduce(
     (acc, report) =>
       acc +
       report.errors.reduce((sum, error) => {
-        const severity = severityByRuleId.get(error.ruleId ?? "");
-        return sum + (severity ? SEVERITY_WEIGHTS[severity] : 0);
+        const severity =
+          severityByRuleId.get(error.ruleId ?? "") ?? RuleSeverity.ERROR;
+        return sum + SEVERITY_WEIGHTS[severity];
       }, 0),
     0,
   );

--- a/src/commands/report-command.handler.ts
+++ b/src/commands/report-command.handler.ts
@@ -8,7 +8,7 @@ import {
 import {
   type Asserter,
   type Report,
-  type ReportStats,
+  RuleSeverity,
   asserterHandler,
 } from "@fixentropy-io/type/asserter";
 import { config } from "../cli.config.ts";
@@ -95,6 +95,7 @@ export const publishReports = async (
   backendUrl: string,
   scanCreditId: UUID,
   reports: Report[],
+  severityByRuleId: Map<string, RuleSeverity>,
 ): Promise<void> => {
   const scanReports: ScanReport[] = reports.map(
     (report): ScanReport => ({
@@ -112,8 +113,7 @@ export const publishReports = async (
     }),
   );
 
-  const stats = reports.map((report) => report.stats);
-  const passRate = calculatePassRate(stats);
+  const passRate = calculatePassRate(reports, severityByRuleId);
 
   const response = await fetch(`${backendUrl}/scans/report`, {
     method: "POST",
@@ -129,16 +129,48 @@ export const publishReports = async (
 };
 
 // ── Calculating Pass Rate ──────────────────────────────────────────────
-// TODO(#19): provisional scoring — every evaluation weighs the same.
-// Weight by error severity once severity levels are defined.
-export const calculatePassRate = (stats: ReportStats[]): number | null => {
-  const totalCount = stats.reduce(
-    (acc, stat) => acc + stat.errorsCount + stat.passCount,
+
+const SEVERITY_WEIGHTS: Record<RuleSeverity, number> = {
+  [RuleSeverity.INFO]: 1,
+  [RuleSeverity.WARN]: 5,
+  [RuleSeverity.ERROR]: 20,
+};
+
+export const buildSeverityByRuleId = (
+  asserters: Asserter[],
+): Map<string, RuleSeverity> =>
+  new Map(
+    asserters.flatMap((asserter) =>
+      asserter.rules.map((rule) => [rule.id, rule.severity] as const),
+    ),
+  );
+
+export const calculatePassRate = (
+  reports: Report[],
+  severityByRuleId: Map<string, RuleSeverity>,
+): number | null => {
+  const totalEvaluations = reports.reduce(
+    (acc, report) => acc + report.stats.passCount + report.stats.errorsCount,
     0,
   );
-  const passCount = stats.reduce((acc, stat) => acc + stat.passCount, 0);
+  if (totalEvaluations === 0) {
+    return null;
+  }
 
-  return totalCount > 0 ? passCount / totalCount : null;
+  const passCount = reports.reduce(
+    (acc, report) => acc + report.stats.passCount,
+    0,
+  );
+  const weightedFailureCount = reports.reduce(
+    (acc, report) =>
+      acc +
+      report.errors.reduce((sum, error) => {
+        const severity = severityByRuleId.get(error.ruleId ?? "");
+        return sum + (severity ? SEVERITY_WEIGHTS[severity] : 0);
+      }, 0),
+    0,
+  );
+  return passCount / (passCount + weightedFailureCount);
 };
 
 // ── Report building ────────────────────────────────────────────────────
@@ -194,10 +226,17 @@ export const reportCommandhandler = async ({
 
     buildReports(reports, `${toDir}/result`);
 
+    console.log(calculatePassRate(reports, buildSeverityByRuleId(asserters)));
+
     // Optionally publish to backend
     if (publish && scanCreditId) {
       console.log(`Publishing ${reports.length} report(s)...`);
-      await publishReports(backendUrl ?? "", scanCreditId, reports);
+      await publishReports(
+        backendUrl ?? "",
+        scanCreditId,
+        reports,
+        buildSeverityByRuleId(asserters),
+      );
     }
 
     askForUpdatesByEmail();

--- a/test/report-command.spec.ts
+++ b/test/report-command.spec.ts
@@ -3,7 +3,7 @@ import {
 	JsonReportBuilder,
 	MarkdownReportBuilder,
 } from "@fixentropy-io/report-generator";
-import type { Report, ReportStats } from "@fixentropy-io/type/asserter";
+import { type Report, RuleSeverity } from "@fixentropy-io/type/asserter";
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { randomUUID } from "node:crypto";
 import { existsSync, unlinkSync } from "node:fs";
@@ -88,46 +88,93 @@ describe("Should display correct reporting format", () => {
 });
 
 describe("calculatePassRate", () => {
-	test("returns the passes over total evaluations across reports", () => {
-		const stats: ReportStats[] = [
-			{ rulesCount: 7, errorsCount: 2, passCount: 5 },
-			{ rulesCount: 5, errorsCount: 1, passCount: 4 },
+	const severityByRuleId = new Map<string, RuleSeverity>([
+		["rule-error", RuleSeverity.ERROR],
+		["rule-warn", RuleSeverity.WARN],
+		["rule-info", RuleSeverity.INFO],
+	]);
+
+	const reportWith = (
+		errors: Report["errors"],
+		passCount: number,
+	): Report => ({
+		namespace: "ns",
+		pass: errors.length === 0,
+		errors,
+		stats: {
+			rulesCount: passCount + errors.length,
+			errorsCount: errors.length,
+			passCount,
+		},
+	});
+
+	test("weights each failure by its rule severity", () => {
+		// 5 passes, one error-severity failure (weight 20) => 5 / (5 + 20)
+		const reports: Report[] = [
+			reportWith(
+				[{ drageeName: "D", message: "m", ruleId: "rule-error" }],
+				5,
+			),
 		];
 
-		expect(calculatePassRate(stats)).toBe(9 / 12);
+		expect(calculatePassRate(reports, severityByRuleId)).toBe(5 / 25);
+	});
+
+	test("mixes severities across reports", () => {
+		// passes: 5 + 4 = 9; failures: error(20) + warn(5) + info(1) = 26
+		const reports: Report[] = [
+			reportWith(
+				[
+					{ drageeName: "A", message: "m", ruleId: "rule-error" },
+					{ drageeName: "B", message: "m", ruleId: "rule-warn" },
+				],
+				5,
+			),
+			reportWith(
+				[{ drageeName: "C", message: "m", ruleId: "rule-info" }],
+				4,
+			),
+		];
+
+		expect(calculatePassRate(reports, severityByRuleId)).toBe(9 / 35);
 	});
 
 	test("returns 1 when every evaluation passes", () => {
-		const stats: ReportStats[] = [
-			{ rulesCount: 4, errorsCount: 0, passCount: 4 },
-		];
-
-		expect(calculatePassRate(stats)).toBe(1);
+		expect(calculatePassRate([reportWith([], 4)], severityByRuleId)).toBe(1);
 	});
 
 	test("returns 0 when every evaluation fails", () => {
-		const stats: ReportStats[] = [
-			{ rulesCount: 4, errorsCount: 4, passCount: 0 },
+		const reports: Report[] = [
+			reportWith(
+				[
+					{ drageeName: "A", message: "m", ruleId: "rule-error" },
+					{ drageeName: "B", message: "m", ruleId: "rule-error" },
+				],
+				0,
+			),
 		];
 
-		expect(calculatePassRate(stats)).toBe(0);
+		expect(calculatePassRate(reports, severityByRuleId)).toBe(0);
 	});
 
 	test("returns null when there are no evaluations", () => {
-		expect(calculatePassRate([])).toBeNull();
-		expect(
-			calculatePassRate([{ rulesCount: 3, errorsCount: 0, passCount: 0 }]),
-		).toBeNull();
+		expect(calculatePassRate([], severityByRuleId)).toBeNull();
+		expect(calculatePassRate([reportWith([], 0)], severityByRuleId)).toBeNull();
 	});
 });
 
 describe("publishReports", () => {
+	const severityByRuleId = new Map<string, RuleSeverity>([
+		["rule-a", RuleSeverity.ERROR],
+		["rule-b", RuleSeverity.WARN],
+	]);
+
 	const reports: Report[] = [
 		{
 			errors: [{ drageeName: "DrageeOne", message: "boom", ruleId: "rule-a" }],
 			namespace: "ddd",
 			pass: false,
-			stats: { rulesCount: 7, errorsCount: 2, passCount: 5 },
+			stats: { rulesCount: 6, errorsCount: 1, passCount: 5 },
 		},
 		{
 			errors: [{ drageeName: "DrageeTwo", message: "boom", ruleId: "rule-b" }],
@@ -142,14 +189,20 @@ describe("publishReports", () => {
 			new Response(null, { status: 200 }),
 		);
 
-		await publishReports("https://backend.test", randomUUID(), reports);
+		await publishReports(
+			"https://backend.test",
+			randomUUID(),
+			reports,
+			severityByRuleId,
+		);
 
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 		const [url, options] = fetchMock.mock.calls[0];
 		expect(url).toBe("https://backend.test/scans/report");
 
 		const body = JSON.parse(options?.body as string);
-		expect(body.score).toBe(9 / 12);
+		// passes 9; weighted failures error(20) + warn(5) = 25
+		expect(body.score).toBe(9 / 34);
 
 		fetchMock.mockRestore();
 	});
@@ -159,14 +212,19 @@ describe("publishReports", () => {
 			new Response(null, { status: 200 }),
 		);
 
-		await publishReports("https://backend.test", randomUUID(), [
-			{
-				errors: [],
-				namespace: "empty",
-				pass: true,
-				stats: { rulesCount: 0, errorsCount: 0, passCount: 0 },
-			},
-		]);
+		await publishReports(
+			"https://backend.test",
+			randomUUID(),
+			[
+				{
+					errors: [],
+					namespace: "empty",
+					pass: true,
+					stats: { rulesCount: 0, errorsCount: 0, passCount: 0 },
+				},
+			],
+			severityByRuleId,
+		);
 
 		const [, options] = fetchMock.mock.calls[0];
 		const body = JSON.parse(options?.body as string);

--- a/test/report-command.spec.ts
+++ b/test/report-command.spec.ts
@@ -1,182 +1,137 @@
 import {
-  HtmlReportBuilder,
-  JsonReportBuilder,
-  MarkdownReportBuilder,
+	HtmlReportBuilder,
+	JsonReportBuilder,
+	MarkdownReportBuilder,
 } from "@fixentropy-io/report-generator";
-import type { Report, ReportStats } from "@fixentropy-io/type/asserter";
+import type { Report } from "@fixentropy-io/type/asserter";
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { existsSync, unlinkSync } from "node:fs";
 import * as newsletterSubscriptionHandler from "../src/commands/newsletter-subscription.handler.ts";
 import * as reportCommandhandler from "../src/commands/report-command.handler.ts";
-import {
-  buildReports,
-  calculateScore,
-} from "../src/commands/report-command.handler.ts";
+import { buildReports } from "../src/commands/report-command.handler.ts";
 
 const testResultFile = "test/result";
 
 afterEach(() => {
-  if (existsSync(testResultFile)) {
-    // Delete test files
-    unlinkSync(`${testResultFile}.json`);
-    unlinkSync(`${testResultFile}.html`);
-    unlinkSync(`${testResultFile}.md`);
-  }
+	if (existsSync(testResultFile)) {
+		// Delete test files
+		unlinkSync(`${testResultFile}.json`);
+		unlinkSync(`${testResultFile}.html`);
+		unlinkSync(`${testResultFile}.md`);
+	}
 });
 
 describe("Should display correct reporting format", () => {
-  test("Format with one report", async () => {
-    const jsonReportBuilderMock = spyOn(JsonReportBuilder, "buildReports");
-    const htmlReportBuilderMock = spyOn(HtmlReportBuilder, "buildReports");
-    const markdownReportBuilderMock = spyOn(
-      MarkdownReportBuilder,
-      "buildReports",
-    );
+	test("Format with one report", async () => {
+		const jsonReportBuilderMock = spyOn(JsonReportBuilder, "buildReports");
+		const htmlReportBuilderMock = spyOn(HtmlReportBuilder, "buildReports");
+		const markdownReportBuilderMock = spyOn(
+			MarkdownReportBuilder,
+			"buildReports",
+		);
 
-    const reports: Report[] = [
-      {
-        errors: [
-          {
-            drageeName: "io.dragee.rules.relation.DrageeOne",
-            message:
-              'This aggregate must at least contain a "ddd/entity" type dragee',
-            ruleId: "ddd/aggregates-allowed-dependencies",
-          },
-          {
-            drageeName: "io.dragee.rules.relation.DrageeTwo",
-            message:
-              'This aggregate must at least contain a "ddd/entity" type dragee',
-            ruleId: "ddd/aggregates-allowed-dependencies",
-          },
-        ],
-        namespace: "ddd",
-        pass: true,
-        stats: {
-          rulesCount: 7,
-          errorsCount: 2,
-          passCount: 5,
-        },
-      },
-      {
-        errors: [
-          {
-            drageeName: "DrageeTestError",
-            message: "Test error",
-            ruleId: "test-error",
-          },
-        ],
-        namespace: "test",
-        pass: true,
-        stats: {
-          rulesCount: 5,
-          errorsCount: 1,
-          passCount: 4,
-        },
-      },
-    ];
-    buildReports(reports, testResultFile);
+		const reports: Report[] = [
+			{
+				errors: [
+					{
+						drageeName: "io.dragee.rules.relation.DrageeOne",
+						message:
+							'This aggregate must at least contain a "ddd/entity" type dragee',
+						ruleId: "ddd/aggregates-allowed-dependencies",
+					},
+					{
+						drageeName: "io.dragee.rules.relation.DrageeTwo",
+						message:
+							'This aggregate must at least contain a "ddd/entity" type dragee',
+						ruleId: "ddd/aggregates-allowed-dependencies",
+					},
+				],
+				namespace: "ddd",
+				pass: true,
+				stats: {
+					rulesCount: 7,
+					errorsCount: 2,
+					passCount: 5,
+				},
+			},
+			{
+				errors: [
+					{
+						drageeName: "DrageeTestError",
+						message: "Test error",
+						ruleId: "test-error",
+					},
+				],
+				namespace: "test",
+				pass: true,
+				stats: {
+					rulesCount: 5,
+					errorsCount: 1,
+					passCount: 4,
+				},
+			},
+		];
+		buildReports(reports, testResultFile);
 
-    expect(jsonReportBuilderMock).toBeCalled();
-    expect(jsonReportBuilderMock).toBeCalledWith(reports, testResultFile);
-    expect(htmlReportBuilderMock).toBeCalled();
-    expect(htmlReportBuilderMock).toBeCalledWith(reports, testResultFile);
-    expect(markdownReportBuilderMock).toBeCalled();
-    expect(markdownReportBuilderMock).toBeCalledWith(reports, testResultFile);
-  });
-});
-
-describe("calculateScore", () => {
-  test("returns the passes over total evaluations across reports", () => {
-    const stats: ReportStats[] = [
-      { rulesCount: 7, errorsCount: 2, passCount: 5 },
-      { rulesCount: 5, errorsCount: 1, passCount: 4 },
-    ];
-
-    expect(calculateScore(stats)).toBe(9 / 12);
-  });
-
-  test("returns 1 when every evaluation passes", () => {
-    const stats: ReportStats[] = [
-      { rulesCount: 4, errorsCount: 0, passCount: 4 },
-    ];
-
-    expect(calculateScore(stats)).toBe(1);
-  });
-
-  test("returns 0 when every evaluation fails", () => {
-    const stats: ReportStats[] = [
-      { rulesCount: 4, errorsCount: 4, passCount: 0 },
-    ];
-
-    expect(calculateScore(stats)).toBe(0);
-  });
-
-  test("returns null when there are no evaluations", () => {
-    expect(calculateScore([])).toBeNull();
-    expect(
-      calculateScore([{ rulesCount: 3, errorsCount: 0, passCount: 0 }]),
-    ).toBeNull();
-  });
+		expect(jsonReportBuilderMock).toBeCalled();
+		expect(jsonReportBuilderMock).toBeCalledWith(reports, testResultFile);
+		expect(htmlReportBuilderMock).toBeCalled();
+		expect(htmlReportBuilderMock).toBeCalledWith(reports, testResultFile);
+		expect(markdownReportBuilderMock).toBeCalled();
+		expect(markdownReportBuilderMock).toBeCalledWith(reports, testResultFile);
+	});
 });
 
 describe("Given a user running the command for the first time", () => {
-  test("it should ask him to get project's updates", async () => {
-    const getUpdatesByEmailHandlerMock = spyOn(
-      newsletterSubscriptionHandler,
-      "getIfOptinChoiceHasBeenMade",
-    ).mockReturnValueOnce(false);
-    const askForEmailMock = spyOn(
-      newsletterSubscriptionHandler,
-      "subscribeToNewsletterHandler",
-    );
+	test("it should ask him to get project's updates", async () => {
+		const getUpdatesByEmailHandlerMock = spyOn(
+			newsletterSubscriptionHandler,
+			"getIfOptinChoiceHasBeenMade",
+		).mockReturnValueOnce(false);
+		const askForEmailMock = spyOn(
+			newsletterSubscriptionHandler,
+			"subscribeToNewsletterHandler",
+		);
 
-    const reportCommanderHandlerMock = spyOn(
-      reportCommandhandler,
-      "buildReports",
-    ).mockImplementation(() => {});
+		const reportCommanderHandlerMock = spyOn(
+			reportCommandhandler,
+			"buildReports",
+		).mockImplementation(() => {});
 
-    await reportCommandhandler.reportCommandhandler({
-      fromDir: "",
-      toDir: "",
-      publish: false,
-    });
+		await reportCommandhandler.reportCommandhandler({ fromDir: "", toDir: "", publish: false });
 
-    expect(askForEmailMock).toHaveBeenCalledTimes(1);
+		expect(askForEmailMock).toHaveBeenCalledTimes(1);
 
-    getUpdatesByEmailHandlerMock.mockClear();
-    reportCommanderHandlerMock.mockClear();
-    askForEmailMock.mockClear();
-  });
+		getUpdatesByEmailHandlerMock.mockClear();
+		reportCommanderHandlerMock.mockClear();
+		askForEmailMock.mockClear();
+	});
 });
 
 describe("Given a user not running the command for the first time", () => {
-  beforeEach(() => {
-    newsletterSubscriptionHandler.checkConfigFile();
-  });
+	beforeEach(() => {
+		newsletterSubscriptionHandler.checkConfigFile();
+	});
 
-  test("it should not ask him to get project's updates", async () => {
-    const getUpdatesByEmailHandlerMock = spyOn(
-      newsletterSubscriptionHandler,
-      "getIfOptinChoiceHasBeenMade",
-    ).mockReturnValueOnce(true);
-    const reportCommanderHandlerMock = spyOn(
-      reportCommandhandler,
-      "buildReports",
-    ).mockImplementation(() => {});
-    const askForEmailMock = spyOn(
-      newsletterSubscriptionHandler,
-      "subscribeToNewsletterHandler",
-    );
+	test("it should not ask him to get project's updates", async () => {
+		const getUpdatesByEmailHandlerMock = spyOn(
+			newsletterSubscriptionHandler,
+			"getIfOptinChoiceHasBeenMade",
+		).mockReturnValueOnce(true);
+		const reportCommanderHandlerMock = spyOn(
+			reportCommandhandler,
+			"buildReports",
+		).mockImplementation(() => {});
+		const askForEmailMock = spyOn(
+			newsletterSubscriptionHandler,
+			"subscribeToNewsletterHandler",
+		);
 
-    await reportCommandhandler.reportCommandhandler({
-      fromDir: "",
-      toDir: "",
-      publish: false,
-    });
-    expect(askForEmailMock).not.toHaveBeenCalled();
+		await reportCommandhandler.reportCommandhandler({ fromDir: "", toDir: "", publish: false });
+		expect(askForEmailMock).not.toHaveBeenCalled();
 
-    getUpdatesByEmailHandlerMock.mockClear();
-    askForEmailMock.mockClear();
-    reportCommanderHandlerMock.mockClear();
-  });
+		getUpdatesByEmailHandlerMock.mockClear();
+		askForEmailMock.mockClear();
+		reportCommanderHandlerMock.mockClear();
+	});
 });

--- a/test/report-command.spec.ts
+++ b/test/report-command.spec.ts
@@ -1,7 +1,7 @@
 import {
-	HtmlReportBuilder,
-	JsonReportBuilder,
-	MarkdownReportBuilder,
+  HtmlReportBuilder,
+  JsonReportBuilder,
+  MarkdownReportBuilder,
 } from "@fixentropy-io/report-generator";
 import type { Report, ReportStats } from "@fixentropy-io/type/asserter";
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
@@ -9,158 +9,174 @@ import { existsSync, unlinkSync } from "node:fs";
 import * as newsletterSubscriptionHandler from "../src/commands/newsletter-subscription.handler.ts";
 import * as reportCommandhandler from "../src/commands/report-command.handler.ts";
 import {
-	buildReports,
-	calculateFailureRate,
+  buildReports,
+  calculateScore,
 } from "../src/commands/report-command.handler.ts";
 
 const testResultFile = "test/result";
 
 afterEach(() => {
-	if (existsSync(testResultFile)) {
-		// Delete test files
-		unlinkSync(`${testResultFile}.json`);
-		unlinkSync(`${testResultFile}.html`);
-		unlinkSync(`${testResultFile}.md`);
-	}
+  if (existsSync(testResultFile)) {
+    // Delete test files
+    unlinkSync(`${testResultFile}.json`);
+    unlinkSync(`${testResultFile}.html`);
+    unlinkSync(`${testResultFile}.md`);
+  }
 });
 
 describe("Should display correct reporting format", () => {
-	test("Format with one report", async () => {
-		const jsonReportBuilderMock = spyOn(JsonReportBuilder, "buildReports");
-		const htmlReportBuilderMock = spyOn(HtmlReportBuilder, "buildReports");
-		const markdownReportBuilderMock = spyOn(
-			MarkdownReportBuilder,
-			"buildReports",
-		);
+  test("Format with one report", async () => {
+    const jsonReportBuilderMock = spyOn(JsonReportBuilder, "buildReports");
+    const htmlReportBuilderMock = spyOn(HtmlReportBuilder, "buildReports");
+    const markdownReportBuilderMock = spyOn(
+      MarkdownReportBuilder,
+      "buildReports",
+    );
 
-		const reports: Report[] = [
-			{
-				errors: [
-					{
-						drageeName: "io.dragee.rules.relation.DrageeOne",
-						message:
-							'This aggregate must at least contain a "ddd/entity" type dragee',
-						ruleId: "ddd/aggregates-allowed-dependencies",
-					},
-					{
-						drageeName: "io.dragee.rules.relation.DrageeTwo",
-						message:
-							'This aggregate must at least contain a "ddd/entity" type dragee',
-						ruleId: "ddd/aggregates-allowed-dependencies",
-					},
-				],
-				namespace: "ddd",
-				pass: true,
-				stats: {
-					rulesCount: 7,
-					errorsCount: 2,
-					passCount: 5,
-				},
-			},
-			{
-				errors: [
-					{
-						drageeName: "DrageeTestError",
-						message: "Test error",
-						ruleId: "test-error",
-					},
-				],
-				namespace: "test",
-				pass: true,
-				stats: {
-					rulesCount: 5,
-					errorsCount: 1,
-					passCount: 4,
-				},
-			},
-		];
-		buildReports(reports, testResultFile);
+    const reports: Report[] = [
+      {
+        errors: [
+          {
+            drageeName: "io.dragee.rules.relation.DrageeOne",
+            message:
+              'This aggregate must at least contain a "ddd/entity" type dragee',
+            ruleId: "ddd/aggregates-allowed-dependencies",
+          },
+          {
+            drageeName: "io.dragee.rules.relation.DrageeTwo",
+            message:
+              'This aggregate must at least contain a "ddd/entity" type dragee',
+            ruleId: "ddd/aggregates-allowed-dependencies",
+          },
+        ],
+        namespace: "ddd",
+        pass: true,
+        stats: {
+          rulesCount: 7,
+          errorsCount: 2,
+          passCount: 5,
+        },
+      },
+      {
+        errors: [
+          {
+            drageeName: "DrageeTestError",
+            message: "Test error",
+            ruleId: "test-error",
+          },
+        ],
+        namespace: "test",
+        pass: true,
+        stats: {
+          rulesCount: 5,
+          errorsCount: 1,
+          passCount: 4,
+        },
+      },
+    ];
+    buildReports(reports, testResultFile);
 
-		expect(jsonReportBuilderMock).toBeCalled();
-		expect(jsonReportBuilderMock).toBeCalledWith(reports, testResultFile);
-		expect(htmlReportBuilderMock).toBeCalled();
-		expect(htmlReportBuilderMock).toBeCalledWith(reports, testResultFile);
-		expect(markdownReportBuilderMock).toBeCalled();
-		expect(markdownReportBuilderMock).toBeCalledWith(reports, testResultFile);
-	});
+    expect(jsonReportBuilderMock).toBeCalled();
+    expect(jsonReportBuilderMock).toBeCalledWith(reports, testResultFile);
+    expect(htmlReportBuilderMock).toBeCalled();
+    expect(htmlReportBuilderMock).toBeCalledWith(reports, testResultFile);
+    expect(markdownReportBuilderMock).toBeCalled();
+    expect(markdownReportBuilderMock).toBeCalledWith(reports, testResultFile);
+  });
 });
 
-describe("calculateFailureRate", () => {
-	test("returns the errors over total evaluations across reports", () => {
-		const stats: ReportStats[] = [
-			{ rulesCount: 7, errorsCount: 2, passCount: 5 },
-			{ rulesCount: 5, errorsCount: 1, passCount: 4 },
-		];
+describe("calculateScore", () => {
+  test("returns the passes over total evaluations across reports", () => {
+    const stats: ReportStats[] = [
+      { rulesCount: 7, errorsCount: 2, passCount: 5 },
+      { rulesCount: 5, errorsCount: 1, passCount: 4 },
+    ];
 
-		expect(calculateFailureRate(stats)).toBe(3 / 12);
-	});
+    expect(calculateScore(stats)).toBe(9 / 12);
+  });
 
-	test("returns 0 when every evaluation passes", () => {
-		const stats: ReportStats[] = [
-			{ rulesCount: 4, errorsCount: 0, passCount: 4 },
-		];
+  test("returns 1 when every evaluation passes", () => {
+    const stats: ReportStats[] = [
+      { rulesCount: 4, errorsCount: 0, passCount: 4 },
+    ];
 
-		expect(calculateFailureRate(stats)).toBe(0);
-	});
+    expect(calculateScore(stats)).toBe(1);
+  });
 
-	test("returns null when there are no evaluations", () => {
-		expect(calculateFailureRate([])).toBeNull();
-		expect(
-			calculateFailureRate([{ rulesCount: 3, errorsCount: 0, passCount: 0 }]),
-		).toBeNull();
-	});
+  test("returns 0 when every evaluation fails", () => {
+    const stats: ReportStats[] = [
+      { rulesCount: 4, errorsCount: 4, passCount: 0 },
+    ];
+
+    expect(calculateScore(stats)).toBe(0);
+  });
+
+  test("returns null when there are no evaluations", () => {
+    expect(calculateScore([])).toBeNull();
+    expect(
+      calculateScore([{ rulesCount: 3, errorsCount: 0, passCount: 0 }]),
+    ).toBeNull();
+  });
 });
 
 describe("Given a user running the command for the first time", () => {
-	test("it should ask him to get project's updates", async () => {
-		const getUpdatesByEmailHandlerMock = spyOn(
-			newsletterSubscriptionHandler,
-			"getIfOptinChoiceHasBeenMade",
-		).mockReturnValueOnce(false);
-		const askForEmailMock = spyOn(
-			newsletterSubscriptionHandler,
-			"subscribeToNewsletterHandler",
-		);
+  test("it should ask him to get project's updates", async () => {
+    const getUpdatesByEmailHandlerMock = spyOn(
+      newsletterSubscriptionHandler,
+      "getIfOptinChoiceHasBeenMade",
+    ).mockReturnValueOnce(false);
+    const askForEmailMock = spyOn(
+      newsletterSubscriptionHandler,
+      "subscribeToNewsletterHandler",
+    );
 
-		const reportCommanderHandlerMock = spyOn(
-			reportCommandhandler,
-			"buildReports",
-		).mockImplementation(() => {});
+    const reportCommanderHandlerMock = spyOn(
+      reportCommandhandler,
+      "buildReports",
+    ).mockImplementation(() => {});
 
-		await reportCommandhandler.reportCommandhandler({ fromDir: "", toDir: "", publish: false });
+    await reportCommandhandler.reportCommandhandler({
+      fromDir: "",
+      toDir: "",
+      publish: false,
+    });
 
-		expect(askForEmailMock).toHaveBeenCalledTimes(1);
+    expect(askForEmailMock).toHaveBeenCalledTimes(1);
 
-		getUpdatesByEmailHandlerMock.mockClear();
-		reportCommanderHandlerMock.mockClear();
-		askForEmailMock.mockClear();
-	});
+    getUpdatesByEmailHandlerMock.mockClear();
+    reportCommanderHandlerMock.mockClear();
+    askForEmailMock.mockClear();
+  });
 });
 
 describe("Given a user not running the command for the first time", () => {
-	beforeEach(() => {
-		newsletterSubscriptionHandler.checkConfigFile();
-	});
+  beforeEach(() => {
+    newsletterSubscriptionHandler.checkConfigFile();
+  });
 
-	test("it should not ask him to get project's updates", async () => {
-		const getUpdatesByEmailHandlerMock = spyOn(
-			newsletterSubscriptionHandler,
-			"getIfOptinChoiceHasBeenMade",
-		).mockReturnValueOnce(true);
-		const reportCommanderHandlerMock = spyOn(
-			reportCommandhandler,
-			"buildReports",
-		).mockImplementation(() => {});
-		const askForEmailMock = spyOn(
-			newsletterSubscriptionHandler,
-			"subscribeToNewsletterHandler",
-		);
+  test("it should not ask him to get project's updates", async () => {
+    const getUpdatesByEmailHandlerMock = spyOn(
+      newsletterSubscriptionHandler,
+      "getIfOptinChoiceHasBeenMade",
+    ).mockReturnValueOnce(true);
+    const reportCommanderHandlerMock = spyOn(
+      reportCommandhandler,
+      "buildReports",
+    ).mockImplementation(() => {});
+    const askForEmailMock = spyOn(
+      newsletterSubscriptionHandler,
+      "subscribeToNewsletterHandler",
+    );
 
-		await reportCommandhandler.reportCommandhandler({ fromDir: "", toDir: "", publish: false });
-		expect(askForEmailMock).not.toHaveBeenCalled();
+    await reportCommandhandler.reportCommandhandler({
+      fromDir: "",
+      toDir: "",
+      publish: false,
+    });
+    expect(askForEmailMock).not.toHaveBeenCalled();
 
-		getUpdatesByEmailHandlerMock.mockClear();
-		askForEmailMock.mockClear();
-		reportCommanderHandlerMock.mockClear();
-	});
+    getUpdatesByEmailHandlerMock.mockClear();
+    askForEmailMock.mockClear();
+    reportCommanderHandlerMock.mockClear();
+  });
 });

--- a/test/report-command.spec.ts
+++ b/test/report-command.spec.ts
@@ -3,12 +3,15 @@ import {
 	JsonReportBuilder,
 	MarkdownReportBuilder,
 } from "@fixentropy-io/report-generator";
-import type { Report } from "@fixentropy-io/type/asserter";
+import type { Report, ReportStats } from "@fixentropy-io/type/asserter";
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { existsSync, unlinkSync } from "node:fs";
 import * as newsletterSubscriptionHandler from "../src/commands/newsletter-subscription.handler.ts";
 import * as reportCommandhandler from "../src/commands/report-command.handler.ts";
-import { buildReports } from "../src/commands/report-command.handler.ts";
+import {
+	buildReports,
+	calculateFailureRate,
+} from "../src/commands/report-command.handler.ts";
 
 const testResultFile = "test/result";
 
@@ -79,6 +82,32 @@ describe("Should display correct reporting format", () => {
 		expect(htmlReportBuilderMock).toBeCalledWith(reports, testResultFile);
 		expect(markdownReportBuilderMock).toBeCalled();
 		expect(markdownReportBuilderMock).toBeCalledWith(reports, testResultFile);
+	});
+});
+
+describe("calculateFailureRate", () => {
+	test("returns the errors over total evaluations across reports", () => {
+		const stats: ReportStats[] = [
+			{ rulesCount: 7, errorsCount: 2, passCount: 5 },
+			{ rulesCount: 5, errorsCount: 1, passCount: 4 },
+		];
+
+		expect(calculateFailureRate(stats)).toBe(3 / 12);
+	});
+
+	test("returns 0 when every evaluation passes", () => {
+		const stats: ReportStats[] = [
+			{ rulesCount: 4, errorsCount: 0, passCount: 4 },
+		];
+
+		expect(calculateFailureRate(stats)).toBe(0);
+	});
+
+	test("returns null when there are no evaluations", () => {
+		expect(calculateFailureRate([])).toBeNull();
+		expect(
+			calculateFailureRate([{ rulesCount: 3, errorsCount: 0, passCount: 0 }]),
+		).toBeNull();
 	});
 });
 

--- a/test/report-command.spec.ts
+++ b/test/report-command.spec.ts
@@ -5,12 +5,14 @@ import {
 } from "@fixentropy-io/report-generator";
 import type { Report, ReportStats } from "@fixentropy-io/type/asserter";
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { randomUUID } from "node:crypto";
 import { existsSync, unlinkSync } from "node:fs";
 import * as newsletterSubscriptionHandler from "../src/commands/newsletter-subscription.handler.ts";
 import * as reportCommandhandler from "../src/commands/report-command.handler.ts";
 import {
 	buildReports,
 	calculatePassRate,
+	publishReports,
 } from "../src/commands/report-command.handler.ts";
 
 const testResultFile = "test/result";
@@ -116,6 +118,61 @@ describe("calculatePassRate", () => {
 		expect(
 			calculatePassRate([{ rulesCount: 3, errorsCount: 0, passCount: 0 }]),
 		).toBeNull();
+	});
+});
+
+describe("publishReports", () => {
+	const reports: Report[] = [
+		{
+			errors: [{ drageeName: "DrageeOne", message: "boom", ruleId: "rule-a" }],
+			namespace: "ddd",
+			pass: false,
+			stats: { rulesCount: 7, errorsCount: 2, passCount: 5 },
+		},
+		{
+			errors: [{ drageeName: "DrageeTwo", message: "boom", ruleId: "rule-b" }],
+			namespace: "test",
+			pass: false,
+			stats: { rulesCount: 5, errorsCount: 1, passCount: 4 },
+		},
+	];
+
+	test("sends the pass rate under the score key in the request body", async () => {
+		const fetchMock = spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(null, { status: 200 }),
+		);
+
+		await publishReports("https://backend.test", randomUUID(), reports);
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const [url, options] = fetchMock.mock.calls[0];
+		expect(url).toBe("https://backend.test/scans/report");
+
+		const body = JSON.parse(options?.body as string);
+		expect(body.score).toBe(9 / 12);
+
+		fetchMock.mockRestore();
+	});
+
+	test("sends score as null when there are no evaluations", async () => {
+		const fetchMock = spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(null, { status: 200 }),
+		);
+
+		await publishReports("https://backend.test", randomUUID(), [
+			{
+				errors: [],
+				namespace: "empty",
+				pass: true,
+				stats: { rulesCount: 0, errorsCount: 0, passCount: 0 },
+			},
+		]);
+
+		const [, options] = fetchMock.mock.calls[0];
+		const body = JSON.parse(options?.body as string);
+		expect(body.score).toBeNull();
+
+		fetchMock.mockRestore();
 	});
 });
 

--- a/test/report-command.spec.ts
+++ b/test/report-command.spec.ts
@@ -3,12 +3,15 @@ import {
 	JsonReportBuilder,
 	MarkdownReportBuilder,
 } from "@fixentropy-io/report-generator";
-import type { Report } from "@fixentropy-io/type/asserter";
+import type { Report, ReportStats } from "@fixentropy-io/type/asserter";
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { existsSync, unlinkSync } from "node:fs";
 import * as newsletterSubscriptionHandler from "../src/commands/newsletter-subscription.handler.ts";
 import * as reportCommandhandler from "../src/commands/report-command.handler.ts";
-import { buildReports } from "../src/commands/report-command.handler.ts";
+import {
+	buildReports,
+	calculatePassRate,
+} from "../src/commands/report-command.handler.ts";
 
 const testResultFile = "test/result";
 
@@ -79,6 +82,40 @@ describe("Should display correct reporting format", () => {
 		expect(htmlReportBuilderMock).toBeCalledWith(reports, testResultFile);
 		expect(markdownReportBuilderMock).toBeCalled();
 		expect(markdownReportBuilderMock).toBeCalledWith(reports, testResultFile);
+	});
+});
+
+describe("calculatePassRate", () => {
+	test("returns the passes over total evaluations across reports", () => {
+		const stats: ReportStats[] = [
+			{ rulesCount: 7, errorsCount: 2, passCount: 5 },
+			{ rulesCount: 5, errorsCount: 1, passCount: 4 },
+		];
+
+		expect(calculatePassRate(stats)).toBe(9 / 12);
+	});
+
+	test("returns 1 when every evaluation passes", () => {
+		const stats: ReportStats[] = [
+			{ rulesCount: 4, errorsCount: 0, passCount: 4 },
+		];
+
+		expect(calculatePassRate(stats)).toBe(1);
+	});
+
+	test("returns 0 when every evaluation fails", () => {
+		const stats: ReportStats[] = [
+			{ rulesCount: 4, errorsCount: 4, passCount: 0 },
+		];
+
+		expect(calculatePassRate(stats)).toBe(0);
+	});
+
+	test("returns null when there are no evaluations", () => {
+		expect(calculatePassRate([])).toBeNull();
+		expect(
+			calculatePassRate([{ rulesCount: 3, errorsCount: 0, passCount: 0 }]),
+		).toBeNull();
 	});
 });
 

--- a/test/report-command.spec.ts
+++ b/test/report-command.spec.ts
@@ -108,8 +108,8 @@ describe("calculatePassRate", () => {
 		},
 	});
 
-	test("weights each failure by its rule severity", () => {
-		// 5 passes, one error-severity failure (weight 20) => 5 / (5 + 20)
+	test("counts each failure with a uniform weight", () => {
+		// 5 passes, one failure (weight 1) => 5 / (5 + 1)
 		const reports: Report[] = [
 			reportWith(
 				[{ drageeName: "D", message: "m", ruleId: "rule-error" }],
@@ -117,11 +117,11 @@ describe("calculatePassRate", () => {
 			),
 		];
 
-		expect(calculatePassRate(reports, severityByRuleId)).toBe(5 / 25);
+		expect(calculatePassRate(reports, severityByRuleId)).toBe(5 / 6);
 	});
 
-	test("mixes severities across reports", () => {
-		// passes: 5 + 4 = 9; failures: error(20) + warn(5) + info(1) = 26
+	test("sums failures across reports", () => {
+		// passes: 5 + 4 = 9; failures: 3 (each weight 1) => 9 / 12
 		const reports: Report[] = [
 			reportWith(
 				[
@@ -136,7 +136,16 @@ describe("calculatePassRate", () => {
 			),
 		];
 
-		expect(calculatePassRate(reports, severityByRuleId)).toBe(9 / 35);
+		expect(calculatePassRate(reports, severityByRuleId)).toBe(9 / 12);
+	});
+
+	test("counts failures with an unknown rule id instead of dropping them", () => {
+		// 5 passes, one failure whose ruleId is absent from the map (weight 1)
+		const reports: Report[] = [
+			reportWith([{ drageeName: "D", message: "m", ruleId: "unknown" }], 5),
+		];
+
+		expect(calculatePassRate(reports, severityByRuleId)).toBe(5 / 6);
 	});
 
 	test("returns 1 when every evaluation passes", () => {
@@ -184,11 +193,19 @@ describe("publishReports", () => {
 		},
 	];
 
-	test("sends the pass rate under the score key in the request body", async () => {
-		const fetchMock = spyOn(globalThis, "fetch").mockResolvedValue(
+	let fetchMock: ReturnType<typeof spyOn<typeof globalThis, "fetch">>;
+
+	beforeEach(() => {
+		fetchMock = spyOn(globalThis, "fetch").mockResolvedValue(
 			new Response(null, { status: 200 }),
 		);
+	});
 
+	afterEach(() => {
+		fetchMock.mockRestore();
+	});
+
+	test("sends the pass rate under the score key in the request body", async () => {
 		await publishReports(
 			"https://backend.test",
 			randomUUID(),
@@ -201,17 +218,11 @@ describe("publishReports", () => {
 		expect(url).toBe("https://backend.test/scans/report");
 
 		const body = JSON.parse(options?.body as string);
-		// passes 9; weighted failures error(20) + warn(5) = 25
-		expect(body.score).toBe(9 / 34);
-
-		fetchMock.mockRestore();
+		// passes 9; failures rule-a + rule-b (each weight 1) = 2
+		expect(body.score).toBe(9 / 11);
 	});
 
 	test("sends score as null when there are no evaluations", async () => {
-		const fetchMock = spyOn(globalThis, "fetch").mockResolvedValue(
-			new Response(null, { status: 200 }),
-		);
-
 		await publishReports(
 			"https://backend.test",
 			randomUUID(),
@@ -229,8 +240,6 @@ describe("publishReports", () => {
 		const [, options] = fetchMock.mock.calls[0];
 		const body = JSON.parse(options?.body as string);
 		expect(body.score).toBeNull();
-
-		fetchMock.mockRestore();
 	});
 });
 


### PR DESCRIPTION
Compute a score from scan stats, send it with published reports, and cover it with tests.

## Changes
- report-command.handler.ts: add `calculatePassRate`, an exported pure function returning passes / (errors + passes), or `null` when there are no evaluations
- report-command.handler.ts: include `passRate` as `score` in the `POST /scans/report` payload
- report-command.spec.ts: add cases for the aggregated ratio, the all-pass case (1), the all-fail case (0), and the no-evaluations case (`null`)

## Testing
- Run `bun test test/report-command.spec.ts`; confirm all cases pass
- Run `report --publish` with `OIDC_TOKEN` and `BACKEND_URL` set against a project with rule violations; confirm the request body to `/scans/report` includes `score` as a 0..1 number
- Run against a project with zero evaluations; confirm `score` is sent as `null`
- Confirm the backend `/scans/report` handler reads and persists `score`, otherwise the field is silently dropped