### PR TITLE
Feat/class diagram

### DIFF
--- a/src/class-diagram.ts
+++ b/src/class-diagram.ts
@@ -1,0 +1,14 @@
+import { lookupForProjects } from '@fixentropy-io/package-installer';
+import type { Dragee } from '@fixentropy-io/type/common';
+import type { Grapher } from '@fixentropy-io/type/grapher';
+import { config } from './cli.config.ts';
+
+export const generateClassDiagram = async (dragees: Dragee[]): Promise<string | undefined> => {
+    const graphers: Grapher[] = await lookupForProjects(
+        config.projectsRegistryUrl,
+        config.localRegistryPath,
+        ['ddd-grapher']
+    );
+
+    return graphers[0].graphs.find(graph => graph.id.endsWith('/class-diagram'))?.handler(dragees);
+};

--- a/src/class-diagram.ts
+++ b/src/class-diagram.ts
@@ -1,18 +1,25 @@
-import { lookupForProjects } from '@fixentropy-io/package-installer';
-import type { Dragee } from '@fixentropy-io/type/common';
-import type { Grapher } from '@fixentropy-io/type/grapher';
-import { config } from './cli.config.ts';
+import { lookupForProjects } from "@fixentropy-io/package-installer";
+import type { Dragee } from "@fixentropy-io/type/common";
+import type { Grapher } from "@fixentropy-io/type/grapher";
+import { config } from "./cli.config.ts";
 
-export const generateClassDiagram = async (dragees: Dragee[]): Promise<string | null> => {
-    try {
-        const graphers: Grapher[] = await lookupForProjects(
-            config.projectsRegistryUrl,
-            config.localRegistryPath,
-            ['ddd-grapher']
-        );
+export const generateClassDiagram = async (
+  dragees: Dragee[],
+): Promise<string | null> => {
+  try {
+    const graphers: Grapher[] = await lookupForProjects(
+      config.projectsRegistryUrl,
+      config.localRegistryPath,
+      ["ddd-grapher"],
+    );
 
-        return graphers[0]?.graphs.find(graph => graph.id.endsWith('/class-diagram'))?.handler(dragees) ?? null;
-    } catch {
-        return null;
-    }
+    return (
+      graphers[0]?.graphs
+        .find((graph) => graph.id.endsWith("/class-diagram"))
+        ?.handler(dragees) ?? null
+    );
+  } catch (error) {
+    console.warn("Class diagram generation failed, skipping.", error);
+    return null;
+  }
 };

--- a/src/class-diagram.ts
+++ b/src/class-diagram.ts
@@ -3,12 +3,12 @@ import type { Dragee } from '@fixentropy-io/type/common';
 import type { Grapher } from '@fixentropy-io/type/grapher';
 import { config } from './cli.config.ts';
 
-export const generateClassDiagram = async (dragees: Dragee[]): Promise<string | undefined> => {
+export const generateClassDiagram = async (dragees: Dragee[]): Promise<string | null> => {
     const graphers: Grapher[] = await lookupForProjects(
         config.projectsRegistryUrl,
         config.localRegistryPath,
         ['ddd-grapher']
     );
 
-    return graphers[0].graphs.find(graph => graph.id.endsWith('/class-diagram'))?.handler(dragees);
+    return graphers[0].graphs.find(graph => graph.id.endsWith('/class-diagram'))?.handler(dragees) ?? null;
 };

--- a/src/class-diagram.ts
+++ b/src/class-diagram.ts
@@ -4,11 +4,15 @@ import type { Grapher } from '@fixentropy-io/type/grapher';
 import { config } from './cli.config.ts';
 
 export const generateClassDiagram = async (dragees: Dragee[]): Promise<string | null> => {
-    const graphers: Grapher[] = await lookupForProjects(
-        config.projectsRegistryUrl,
-        config.localRegistryPath,
-        ['ddd-grapher']
-    );
+    try {
+        const graphers: Grapher[] = await lookupForProjects(
+            config.projectsRegistryUrl,
+            config.localRegistryPath,
+            ['ddd-grapher']
+        );
 
-    return graphers[0].graphs.find(graph => graph.id.endsWith('/class-diagram'))?.handler(dragees) ?? null;
+        return graphers[0]?.graphs.find(graph => graph.id.endsWith('/class-diagram'))?.handler(dragees) ?? null;
+    } catch {
+        return null;
+    }
 };

--- a/src/commands/report-command.handler.ts
+++ b/src/commands/report-command.handler.ts
@@ -97,7 +97,7 @@ export const publishReports = async (
   scanCreditId: UUID,
   reports: Report[],
   severityByRuleId: Map<string, RuleSeverity>,
-  classDiagram: string | undefined,
+  classDiagram: string | null,
 ): Promise<void> => {
   const scanReports: ScanReport[] = reports.map(
     (report): ScanReport => ({

--- a/src/commands/report-command.handler.ts
+++ b/src/commands/report-command.handler.ts
@@ -11,6 +11,7 @@ import {
   RuleSeverity,
   asserterHandler,
 } from "@fixentropy-io/type/asserter";
+import { generateClassDiagram } from "../class-diagram.ts";
 import { config } from "../cli.config.ts";
 import { lookupForDragees } from "../dragee-lookup.ts";
 import { lookupForNamespaces } from "../namespace-lookup.ts";
@@ -96,6 +97,7 @@ export const publishReports = async (
   scanCreditId: UUID,
   reports: Report[],
   severityByRuleId: Map<string, RuleSeverity>,
+  classDiagram: string | undefined,
 ): Promise<void> => {
   const scanReports: ScanReport[] = reports.map(
     (report): ScanReport => ({
@@ -118,7 +120,7 @@ export const publishReports = async (
   const response = await fetch(`${backendUrl}/scans/report`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ scanCreditId, reports: scanReports, score: passRate }),
+    body: JSON.stringify({ scanCreditId, reports: scanReports, score: passRate, classDiagram }),
   });
 
   if (!response.ok) {
@@ -231,11 +233,13 @@ export const reportCommandhandler = async ({
     // Optionally publish to backend
     if (publish && scanCreditId) {
       console.log(`Publishing ${reports.length} report(s)...`);
+      const classDiagram = await generateClassDiagram(dragees);
       await publishReports(
         backendUrl ?? "",
         scanCreditId,
         reports,
         buildSeverityByRuleId(asserters),
+        classDiagram,
       );
     }
 

--- a/test/class-diagram.spec.ts
+++ b/test/class-diagram.spec.ts
@@ -1,0 +1,50 @@
+import * as packageInstaller from "@fixentropy-io/package-installer";
+import type { Dragee } from "@fixentropy-io/type/common";
+import type { Grapher } from "@fixentropy-io/type/grapher";
+import { afterAll, describe, expect, spyOn, test } from "bun:test";
+import { generateClassDiagram } from "../src/class-diagram.ts";
+
+const lookupMock = spyOn(packageInstaller, "lookupForProjects");
+
+afterAll(() => {
+	lookupMock.mockRestore();
+});
+
+const dragees: Dragee[] = [];
+
+describe("generateClassDiagram", () => {
+	test("returns the class-diagram handler output on the nominal path", async () => {
+		lookupMock.mockResolvedValueOnce([
+			{
+				namespace: "ddd",
+				graphs: [
+					{
+						id: "ddd/class-diagram",
+						label: "class-diagram",
+						handler: () => "classDiagram\n  class Foo",
+					},
+				],
+			},
+		] satisfies Grapher[]);
+
+		expect(await generateClassDiagram(dragees)).toBe("classDiagram\n  class Foo");
+	});
+
+	test("returns null when no grapher is resolved", async () => {
+		lookupMock.mockResolvedValueOnce([]);
+
+		expect(await generateClassDiagram(dragees)).toBeNull();
+	});
+
+	test("returns null when the grapher has no class-diagram graph", async () => {
+		lookupMock.mockResolvedValueOnce([{ namespace: "ddd", graphs: [] }]);
+
+		expect(await generateClassDiagram(dragees)).toBeNull();
+	});
+
+	test("returns null when the lookup itself throws", async () => {
+		lookupMock.mockRejectedValueOnce(new Error("registry unreachable"));
+
+		expect(await generateClassDiagram(dragees)).toBeNull();
+	});
+});

--- a/test/report-command.spec.ts
+++ b/test/report-command.spec.ts
@@ -243,6 +243,36 @@ describe("publishReports", () => {
 		const body = JSON.parse(options?.body as string);
 		expect(body.score).toBeNull();
 	});
+
+	test("sends the class diagram under the classDiagram key in the request body", async () => {
+		const classDiagram = "classDiagram\n  class DrageeOne";
+
+		await publishReports(
+			"https://backend.test",
+			randomUUID(),
+			reports,
+			severityByRuleId,
+			classDiagram,
+		);
+
+		const [, options] = fetchMock.mock.calls[0];
+		const body = JSON.parse(options?.body as string);
+		expect(body.classDiagram).toBe(classDiagram);
+	});
+
+	test("sends classDiagram as null when no diagram is provided", async () => {
+		await publishReports(
+			"https://backend.test",
+			randomUUID(),
+			reports,
+			severityByRuleId,
+			null,
+		);
+
+		const [, options] = fetchMock.mock.calls[0];
+		const body = JSON.parse(options?.body as string);
+		expect(body.classDiagram).toBeNull();
+	});
 });
 
 describe("Given a user running the command for the first time", () => {

--- a/test/report-command.spec.ts
+++ b/test/report-command.spec.ts
@@ -211,6 +211,7 @@ describe("publishReports", () => {
 			randomUUID(),
 			reports,
 			severityByRuleId,
+			undefined,
 		);
 
 		expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -235,6 +236,7 @@ describe("publishReports", () => {
 				},
 			],
 			severityByRuleId,
+			undefined,
 		);
 
 		const [, options] = fetchMock.mock.calls[0];

--- a/test/report-command.spec.ts
+++ b/test/report-command.spec.ts
@@ -211,7 +211,7 @@ describe("publishReports", () => {
 			randomUUID(),
 			reports,
 			severityByRuleId,
-			undefined,
+			null,
 		);
 
 		expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -236,7 +236,7 @@ describe("publishReports", () => {
 				},
 			],
 			severityByRuleId,
-			undefined,
+			null,
 		);
 
 		const [, options] = fetchMock.mock.calls[0];


### PR DESCRIPTION
Include the class diagram in the published scan report.

## Changes
- src/class-diagram.ts: new generateClassDiagram, resolves the ddd-grapher package and runs its agnostic class-diagram handler, returns string | null
- src/commands/report-command.handler.ts: produce the diagram before publish, add classDiagram param to publishReports, send it in the /scans/report body alongside score
- test/report-command.spec.ts: pass classDiagram (null) in the two publishReports calls

## Testing
- Run: `bun test test/report-command.spec.ts`
- Verify the POST body to /scans/report contains "classDiagram" (string when the grapher produces one, null otherwise) rather than the key being omitted
- Run a real publish (`--publish`) against a project and confirm the request carries the mermaid source